### PR TITLE
[Feat] Add print final ranking at GameOverScene

### DIFF
--- a/MultiMaze/MazeServer/Scenes/GameOverServerScene.cs
+++ b/MultiMaze/MazeServer/Scenes/GameOverServerScene.cs
@@ -3,10 +3,56 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Net;
+using MazeClient.Share;
 
 namespace MazeServer.Scenes
 {
     internal class GameOverServerScene
     {
+        ServerGameManager manager;
+        public GameOverServerScene()
+        {
+            manager = ServerGameManager.Instance;
+            manager.client.callbackFunctions.GameOverSceneCallBack = null;
+            manager.client.callbackFunctions.GameOverSceneCallBack += GameOverSceneCallBackFunction;
+        }
+        public void GameOverSceneCallBackFunction(byte[] buffer, ServerEvent serverEvent, int playerCode)
+        {
+            //GameStatus 확인
+            if (serverEvent.GameStatus != Define.GameState.GameOverScene) return;
+            switch (serverEvent.EventType)
+            {
+                case 0:  //path
+                    receiveRequestPath(playerCode);
+                    break;
+                case 1: // none
+                    break;
+            }
+        }
+
+        private void receiveRequestPath(int playerCode)
+        {
+            /*어떤 경우를 출력하기로 했는지 까먹어서 일단 랜덤 라운드 출력하였습니다.*/
+            //System.Random rand = new System.Random();
+            //int randomRound = rand.Next(0, 5);
+            List<Point> path = manager.WinnerPathList[0];
+
+            byte[] buffer = new byte[path.Count * 4];
+            byte[] xbuffer = new byte[2];
+            byte[] ybuffer = new byte[2];
+            for (int i = 0; i < path.Count; i++)
+            {
+                xbuffer = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)path[i].X));
+                ybuffer = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)path[i].Y));
+
+                Array.Copy(xbuffer, 0, buffer, 4 * i, 2);
+                Array.Copy(ybuffer, 0, buffer, 4 * i + 2, 2);
+            }
+
+            ServerEvent serverEvent = new ServerEvent(Define.GameState.GameOverScene, 0);
+
+            manager.client.SendToPlayer(buffer, serverEvent, playerCode);
+        }
     }
 }

--- a/MultiMaze/MultiTowerDefence/Scenes/GameOverScene.Designer.cs
+++ b/MultiMaze/MultiTowerDefence/Scenes/GameOverScene.Designer.cs
@@ -32,9 +32,9 @@
             pictureBox3 = new PictureBox();
             roundLabel = new Label();
             panel1 = new Panel();
+            Third = new Label();
             First = new Label();
             Second = new Label();
-            Third = new Label();
             ((System.ComponentModel.ISupportInitialize)pictureBox3).BeginInit();
             panel1.SuspendLayout();
             SuspendLayout();
@@ -79,17 +79,27 @@
             panel1.Controls.Add(Third);
             panel1.Controls.Add(First);
             panel1.Controls.Add(Second);
-            panel1.Location = new Point(23, 363);
+            panel1.Location = new Point(23, 395);
             panel1.Margin = new Padding(2);
             panel1.Name = "panel1";
-            panel1.Size = new Size(355, 105);
+            panel1.Size = new Size(355, 73);
             panel1.TabIndex = 23;
+            // 
+            // Third
+            // 
+            Third.AutoSize = true;
+            Third.BackColor = Color.LightGray;
+            Third.Location = new Point(12, 52);
+            Third.Name = "Third";
+            Third.Size = new Size(37, 15);
+            Third.TabIndex = 11;
+            Third.Text = "3등 : ";
             // 
             // First
             // 
             First.AutoSize = true;
             First.BackColor = Color.LightGray;
-            First.Location = new Point(12, 16);
+            First.Location = new Point(12, 6);
             First.Name = "First";
             First.Size = new Size(37, 15);
             First.TabIndex = 8;
@@ -99,21 +109,11 @@
             // 
             Second.AutoSize = true;
             Second.BackColor = Color.LightGray;
-            Second.Location = new Point(12, 46);
+            Second.Location = new Point(12, 29);
             Second.Name = "Second";
             Second.Size = new Size(37, 15);
             Second.TabIndex = 10;
             Second.Text = "2등 : ";
-            // 
-            // Third
-            // 
-            Third.AutoSize = true;
-            Third.BackColor = Color.LightGray;
-            Third.Location = new Point(12, 76);
-            Third.Name = "Third";
-            Third.Size = new Size(37, 15);
-            Third.TabIndex = 11;
-            Third.Text = "3등 : ";
             // 
             // GameOverScene
             // 

--- a/MultiMaze/MultiTowerDefence/Scenes/GameOverScene.cs
+++ b/MultiMaze/MultiTowerDefence/Scenes/GameOverScene.cs
@@ -6,25 +6,200 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
 
 namespace MazeClient
 {
     public partial class GameOverScene : Form
     {
         GameManager Manager;
+        bool[,] map;
+        List<Point> path;
+        int cellSize = 4;
+        int mazeHeight;
+        int mazeWidth;
+
+        //맵 & 경로 출력 시작 좌표
+        int startX = 30;
+        int startY = 90;
         public GameOverScene()
         {
             InitializeComponent();
             Manager = GameManager.Instance;
+            Manager.server.callbackFunctions.GameOverSceneCallBack = null;
+            Manager.server.callbackFunctions.GameOverSceneCallBack += GameOverSceneCallBackFunction;
+            this.DoubleBuffered = true; // 로딩 잘 되게 합니다.
+
+            switch (Manager.map.RoomArgs.mapSize)
+            {
+                case RoomSettingArgs.MapSize.Small:
+                    cellSize = 10;
+                    break;
+                case RoomSettingArgs.MapSize.Medium:
+                    cellSize = 6;
+                    break;
+                case RoomSettingArgs.MapSize.Big:
+                    cellSize = 4;
+                    break;
+            }
+
+            getWinnerPath();
+            CalculateFinalRanking();
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        int count = 0;
+        private void WinnerPath_Draw(object sender, PaintEventArgs e)
         {
-            Manager.scene.ChangeGameState(this, Define.GameState.MainScene);
+
+            Graphics g = e.Graphics;
+
+
+            //미로 그리기 
+            for (int i = 0; i < mazeHeight - 1; i++)
+            {
+                for (int j = 0; j < mazeWidth - 1; j++)
+                {
+                    Color color = map[i, j] ? Color.White : Color.Black;
+                    g.FillRectangle(new SolidBrush(color), startX + i * cellSize, startY + j * cellSize, cellSize, cellSize);
+                }
+            }
+
+            //경로 그리기
+            Pen pen = new Pen(Color.Red, cellSize / 2);
+            if (path != null && path.Count > 1)
+            {
+                for (int i = 1; i < count; i++)
+                {
+                    Point prev = CalculatePoint(i - 1);
+                    Point curr = CalculatePoint(i);
+                    g.DrawLine(pen, prev, curr);
+                }
+            }
+
+
+            count++;
+            if (count == path.Count)
+            {
+                count = 0;
+            }
         }
+
+        private Point CalculatePoint(int index)
+        {
+            return new Point(startX + path[index].X * cellSize + cellSize / 2, startY + path[index].Y * cellSize + cellSize / 2);
+        }
+
+        public void GameOverSceneCallBackFunction(byte[] buffer, ServerEvent serverEvent)
+        {
+            //GameStatus 확인
+            if (serverEvent.GameStatus != Define.GameState.GameOverScene) return;
+            switch (serverEvent.EventType)
+            {
+                case 0: // Path
+                    receiveWinnerPath(buffer);
+                    //함수
+                    break;
+                case 1: // None 
+                    break;
+            }
+        }
+
+
+        public void CalculateFinalRanking()
+        {
+            //AI는 0번, player는 player번호로 저장
+            Dictionary<int, int> playerScores = new Dictionary<int, int>();
+
+            // 최종점수 초기화
+            for (int i = 0; i <= GameManager.MAX_PLAYER_NUM; i++)
+            {
+                if (i == 0 || Manager.server.PlayerConnectArray[i - 1])
+                {
+                    playerScores[i] = 0;
+                }
+            }
+
+            //각 라운드별 승자에게 2점씩 부여
+            foreach (int winner in Manager.WinnerList)
+            {
+                if (playerScores.ContainsKey(winner))
+                {
+                    playerScores[winner] += 2;
+                }
+            }
+
+            // 랭킹 정렬
+            var rankedPlayers = playerScores.OrderByDescending(pair => pair.Value).ToList();
+
+            // 랭킹 출력
+            for (int i = 0; i < rankedPlayers.Count; i++)
+            {
+                string playerType = rankedPlayers[i].Key == 0 ? "AI" : $"{rankedPlayers[i].Key}번 플레이어";
+                switch (i)
+                {
+                    case 0:
+                        First.Text = "1등: " + playerType;
+                        break;
+                    case 1:
+                        Second.Text = "2등: " + playerType;
+                        break;
+                    case 2:
+                        Third.Text = "3등: " + playerType;
+                        break;
+                }
+            }
+        }
+
+            #region 서버 송신
+            private void getWinnerPath()
+        {
+            //서버한테 path달라고
+            int playerCode = Manager.PlayerCode;
+            // 직렬화
+            byte[] buffer = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)playerCode));
+            // 서버이벤트
+            GameOverSceneEvent serverEvent = new GameOverSceneEvent(GameOverSceneEvent.GameOverSceneServerEventType.Path);
+            // 송신
+            Manager.server.SendToServerAsync(buffer, serverEvent);
+        }
+        #endregion
+
+        #region 서버 수신
+        private async void receiveWinnerPath(byte[] buffer)
+        {
+            List<Point> newpath = new List<Point>();
+
+            byte[] xBuffer = new byte[2];
+            byte[] yBuffer = new byte[2];
+            int len = buffer.Length / 4;
+            for (int i = 0; i < len; i++)
+            {
+                Array.Copy(buffer, 4 * i, xBuffer, 0, 2);
+                Array.Copy(buffer, 4 * i + 2, yBuffer, 0, 2);
+
+                int x = IPAddress.NetworkToHostOrder(BitConverter.ToInt16(xBuffer, 0));
+                int y = IPAddress.NetworkToHostOrder(BitConverter.ToInt16(yBuffer, 0));
+                newpath.Add(new Point(x, y));
+            }
+
+            path = newpath;
+            Manager.path = path;
+            map = Manager.map.map;
+            mazeHeight = map.GetLength(0);
+            mazeWidth = map.GetLength(1);
+
+            await Task.Delay(30);
+            this.Paint += new PaintEventHandler(WinnerPath_Draw);
+            this.Invalidate();
+        }
+
+        #endregion
 
         private void BackToMain_Click(object sender, EventArgs e)
         {
@@ -33,6 +208,26 @@ namespace MazeClient
             GameManager.Refresh();
             GameManager.Instance.scene.baseScene = temp;
             Manager.scene.ChangeGameState(this, Define.GameState.MainScene);
+        }
+    }
+
+    public class GameOverSceneEvent : ServerEvent
+    {
+        public enum GameOverSceneServerEventType
+        {
+            Path, None
+        }
+
+
+        public GameOverSceneEvent() : base()
+        {
+            EventType = (int)GameOverSceneServerEventType.None;
+            GameStatus = Define.GameState.GameOverScene;
+        }
+        public GameOverSceneEvent(GameOverSceneServerEventType gameOverSceneServerEventType) : base()
+        {
+            EventType = (int)gameOverSceneServerEventType;
+            GameStatus = Define.GameState.GameOverScene;
         }
     }
 }


### PR DESCRIPTION
순위 라운드별 승자에게 2점씩 계산해서 출력되는 것 확인하였습니다. 다만 문제가 1라운드로 설정한 경기에서는 승자 기록이 잘 안되는 모양입니다? 1라운드 경기로 만들면 AI가 이겼다고 항상 나오네요. 3라운드 이상에서는 정상적으로 순위가 출력되는게 확인 되었습니다. 뭔가 원인을 분석하기에는 뇌가 잠을 원해서 일단 자고 어디가 문제인지 다시 보도록 하겠습니다. 아마 InGame 내부 아니면 GameOver 순위계산 로직의 문제가 있을 것 같습니다.

경로까지 랜덤 라운드 출력하려고 했는데 뭔가 잘 안나오지만, 마찬가지로 뇌가 잠을 원해서 일단 자고 미팅때 다시 수정해 보도록 하겠습니다.